### PR TITLE
feat: add fantasy matchups page with ui components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+Dist
+vite.config.ts.timestamp-*
+

--- a/README.md
+++ b/README.md
@@ -1,53 +1,40 @@
 # GridIron IQ
 
-GridIron IQ is an analytics‑focused fantasy football dashboard. This repository
-contains a minimal React + Vite scaffold that you can build on to create
-interactive matchup visualizations, roster views, and advanced metrics for your
-league.
+GridIron IQ is a fantasy football analytics dashboard built with React and Vite.
+It syncs league data from the [Sleeper](https://api.sleeper.app) API and exposes a
+pluggable provider system for optional analytics such as projections, injuries and weather.
+
+Current tabs include:
+
+- **Matchups** – synthetic time-series chart and scoreboard for the selected week.
+- **League** – roster cards with cached player dictionary lookup.
+- **Player Analytics** – placeholder for projections, injuries and news providers.
+- **Team Analytics** – placeholder for pace and red-zone trends.
+- **Fun Metrics** – placeholder for experimental stats like Hype Volatility.
 
 ## Getting Started
 
-1. Install dependencies:
+```bash
+npm install
+npm run dev
+```
 
-   ```bash
-   npm install
-   ```
+Open <http://localhost:5173> in your browser.
 
-2. Run the development server:
+## Tests
 
-   ```bash
-   npm run dev
-   ```
+```bash
+npm test
+```
 
-3. Open your browser to `http://localhost:5173` to view the app. Edit files
-   under `src/` and the page will reload automatically.
+## Environment
 
-## Architecture
+Optional providers are controlled via env variables:
 
-This app uses the following core technologies:
+- `VITE_PROJECTIONS_ENABLED`
+- `VITE_INJURIES_ENABLED`
+- `VITE_WEATHER_ENABLED`
+- `VITE_ODDS_ENABLED`
+- `VITE_NEWS_ENABLED`
 
-- **React** for building the UI components.
-- **Vite** for bundling and development server.
-- **TypeScript** for static typing.
-- **recharts** for plotting charts.
-- **framer-motion** and **lucide-react** for animations and icons.
-
-The entry point is [`src/main.tsx`](src/main.tsx) which mounts the root
-component defined in [`src/App.tsx`](src/App.tsx).
-
-## Next Steps
-
-This scaffold only contains a basic starter page. To build out your fantasy
-football analytics dashboard:
-
-1. Add components under `src/components` for charts, roster cards, matchup
-   scoreboards, etc.
-2. Implement data fetching from the Sleeper API in a separate module (e.g.
-   `src/api/sleeper.ts`). Use `/state/nfl` to detect the current week and
-   `/league/{league_id}` and related endpoints to pull league, roster and
-   matchup data.
-3. Generate synthetic time series for matchup point progressions if desired.
-4. Optionally integrate additional providers (projections, injuries, weather,
-   odds, news) behind clearly defined interfaces.
-
-Happy coding!
+API keys should be provided as additional env variables when enabling a provider.

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GridIron IQ</title>
   </head>
-  <body>
+  <body class="bg-gray-50 text-gray-900">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-  </body>
+</body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2859 @@
+{
+  "name": "gridiron-iq",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gridiron-iq",
+      "version": "0.1.0",
+      "dependencies": {
+        "framer-motion": "11.2.12",
+        "lucide-react": "0.378.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "recharts": "2.8.0",
+        "tailwindcss": "4.1.10"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "4.3.2",
+        "typescript": "5.8.3",
+        "vitest": "1.6.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
+      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.3",
+        "@babel/parser": "^7.28.3",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
+      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.3",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.2",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.48.0.tgz",
+      "integrity": "sha512-aVzKH922ogVAWkKiyKXorjYymz2084zrhrZRXtLrA5eEx5SO8Dj0c/4FpCHZyn7MKzhW2pW4tK28vVr+5oQ2xw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.48.0.tgz",
+      "integrity": "sha512-diOdQuw43xTa1RddAFbhIA8toirSzFMcnIg8kvlzRbK26xqEnKJ/vqQnghTAajy2Dcy42v+GMPMo6jq67od+Dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.48.0.tgz",
+      "integrity": "sha512-QhR2KA18fPlJWFefySJPDYZELaVqIUVnYgAOdtJ+B/uH96CFg2l1TQpX19XpUMWUqMyIiyY45wje8K6F4w4/CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.48.0.tgz",
+      "integrity": "sha512-Q9RMXnQVJ5S1SYpNSTwXDpoQLgJ/fbInWOyjbCnnqTElEyeNvLAB3QvG5xmMQMhFN74bB5ZZJYkKaFPcOG8sGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.48.0.tgz",
+      "integrity": "sha512-3jzOhHWM8O8PSfyft+ghXZfBkZawQA0PUGtadKYxFqpcYlOYjTi06WsnYBsbMHLawr+4uWirLlbhcYLHDXR16w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.48.0.tgz",
+      "integrity": "sha512-NcD5uVUmE73C/TPJqf78hInZmiSBsDpz3iD5MF/BuB+qzm4ooF2S1HfeTChj5K4AV3y19FFPgxonsxiEpy8v/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.48.0.tgz",
+      "integrity": "sha512-JWnrj8qZgLWRNHr7NbpdnrQ8kcg09EBBq8jVOjmtlB3c8C6IrynAJSMhMVGME4YfTJzIkJqvSUSVJRqkDnu/aA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.48.0.tgz",
+      "integrity": "sha512-9xu92F0TxuMH0tD6tG3+GtngwdgSf8Bnz+YcsPG91/r5Vgh5LNofO48jV55priA95p3c92FLmPM7CvsVlnSbGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.48.0.tgz",
+      "integrity": "sha512-NLtvJB5YpWn7jlp1rJiY0s+G1Z1IVmkDuiywiqUhh96MIraC0n7XQc2SZ1CZz14shqkM+XN2UrfIo7JB6UufOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.48.0.tgz",
+      "integrity": "sha512-QJ4hCOnz2SXgCh+HmpvZkM+0NSGcZACyYS8DGbWn2PbmA0e5xUk4bIP8eqJyNXLtyB4gZ3/XyvKtQ1IFH671vQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.48.0.tgz",
+      "integrity": "sha512-Pk0qlGJnhILdIC5zSKQnprFjrGmjfDM7TPZ0FKJxRkoo+kgMRAg4ps1VlTZf8u2vohSicLg7NP+cA5qE96PaFg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.48.0.tgz",
+      "integrity": "sha512-/dNFc6rTpoOzgp5GKoYjT6uLo8okR/Chi2ECOmCZiS4oqh3mc95pThWma7Bgyk6/WTEvjDINpiBCuecPLOgBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.48.0.tgz",
+      "integrity": "sha512-YBwXsvsFI8CVA4ej+bJF2d9uAeIiSkqKSPQNn0Wyh4eMDY4wxuSp71BauPjQNCKK2tD2/ksJ7uhJ8X/PVY9bHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.48.0.tgz",
+      "integrity": "sha512-FI3Rr2aGAtl1aHzbkBIamsQyuauYtTF9SDUJ8n2wMXuuxwchC3QkumZa1TEXYIv/1AUp1a25Kwy6ONArvnyeVQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.48.0.tgz",
+      "integrity": "sha512-Dx7qH0/rvNNFmCcIRe1pyQ9/H0XO4v/f0SDoafwRYwc2J7bJZ5N4CHL/cdjamISZ5Cgnon6iazAVRFlxSoHQnQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.48.0.tgz",
+      "integrity": "sha512-GUdZKTeKBq9WmEBzvFYuC88yk26vT66lQV8D5+9TgkfbewhLaTHRNATyzpQwwbHIfJvDJ3N9WJ90wK/uR3cy3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.48.0.tgz",
+      "integrity": "sha512-ao58Adz/v14MWpQgYAb4a4h3fdw73DrDGtaiF7Opds5wNyEQwtO6M9dBh89nke0yoZzzaegq6J/EXs7eBebG8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.48.0.tgz",
+      "integrity": "sha512-kpFno46bHtjZVdRIOxqaGeiABiToo2J+st7Yce+aiAoo1H0xPi2keyQIP04n2JjDVuxBN6bSz9R6RdTK5hIppw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.48.0.tgz",
+      "integrity": "sha512-rFYrk4lLk9YUTIeihnQMiwMr6gDhGGSbWThPEDfBoU/HdAtOzPXeexKi7yU8jO+LWRKnmqPN9NviHQf6GDwBcQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.48.0.tgz",
+      "integrity": "sha512-sq0hHLTgdtwOPDB5SJOuaoHyiP1qSwg+71TQWk8iDS04bW1wIE0oQ6otPiRj2ZvLYNASLMaTp8QRGUVZ+5OL5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.2.tgz",
+      "integrity": "sha512-hieu+o05v4glEBucTcKMK3dlES0OeJlD9YVOAPraVMOInBCwzumaIFiUjr4bHK7NPgnAHgiskUoceKercrN8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.14.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
+      "integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.0",
+        "@vitest/utils": "1.6.0",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.0.tgz",
+      "integrity": "sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.0",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.0.tgz",
+      "integrity": "sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
+      "integrity": "sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.25.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
+      "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001735",
+        "electron-to-chromium": "^1.5.204",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001737",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
+      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-unit-converter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
+      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.208",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.208.tgz",
+      "integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.2.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.2.12.tgz",
+      "integrity": "sha512-lCjkV4nA9rWOy2bhR4RZzkp2xpB++kFmUZ6D44V9VQaxk+JDmbDd5lq+u58DjJIIllE8AZEXp9OG/TyDN4FB/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.378.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.378.0.tgz",
+      "integrity": "sha512-u6EPU8juLUk9ytRcyapkWI18epAv3RU+6+TC23ivjR0e+glWKBobFeSgRwOIJihzktILQuy6E0E80P2jVTDR5g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.18",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resize-detector": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.1.0.tgz",
+      "integrity": "sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.5.tgz",
+      "integrity": "sha512-BMP2Ad42tD60h0JW6BFaib+RJuV5dsXJK9Baxiv/HlNFjvRLqA9xrNKxVWnUIZPQfzUwGXIlU/dSYLU+54YGQA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.0",
+        "react-transition-group": "2.9.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.8.0.tgz",
+      "integrity": "sha512-nciXqQDh3aW8abhwUlA4EBOBusRHLNiKHfpRZiG/yjups1x+auHb2zWPuEcTn/IMiN47vVMMuF8Sr+vcQJtsmw==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "^16.10.2",
+        "react-resize-detector": "^8.0.4",
+        "react-smooth": "^2.0.2",
+        "recharts-scale": "^0.4.4",
+        "reduce-css-calc": "^2.1.8",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/reduce-css-calc": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
+      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-unit-converter": "^1.1.1",
+        "postcss-value-parser": "^3.3.0"
+      }
+    },
+    "node_modules/reduce-css-calc/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.48.0.tgz",
+      "integrity": "sha512-BXHRqK1vyt9XVSEHZ9y7xdYtuYbwVod2mLwOMFP7t/Eqoc1pHRlG/WdV2qNeNvZHRQdLedaFycljaYYM96RqJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.48.0",
+        "@rollup/rollup-android-arm64": "4.48.0",
+        "@rollup/rollup-darwin-arm64": "4.48.0",
+        "@rollup/rollup-darwin-x64": "4.48.0",
+        "@rollup/rollup-freebsd-arm64": "4.48.0",
+        "@rollup/rollup-freebsd-x64": "4.48.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.48.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.48.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.48.0",
+        "@rollup/rollup-linux-arm64-musl": "4.48.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.48.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.48.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.48.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.48.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.48.0",
+        "@rollup/rollup-linux-x64-gnu": "4.48.0",
+        "@rollup/rollup-linux-x64-musl": "4.48.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.48.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.48.0",
+        "@rollup/rollup-win32-x64-msvc": "4.48.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz",
+      "integrity": "sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.0.tgz",
+      "integrity": "sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
+      "integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.0",
+        "@vitest/runner": "1.6.0",
+        "@vitest/snapshot": "1.6.0",
+        "@vitest/spy": "1.6.0",
+        "@vitest/utils": "1.6.0",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.0",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.0",
+        "@vitest/ui": "1.6.0",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,20 +1,23 @@
 {
+  "name": "gridiron-iq",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "test": "vitest"
+  },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.7.2",
-    "@fortawesome/fontawesome-svg-core": "6.7.2",
-    "@fortawesome/free-brands-svg-icons": "6.7.2",
-    "@fortawesome/free-regular-svg-icons": "6.7.2",
-    "@fortawesome/free-solid-svg-icons": "6.7.2",
-    "@types/prismjs": "1.26.5",
-    "autoprefixer": "10.4.21",
-    "http-server": "14.1.1",
-    "image-size": "2.0.2",
-    "postcss": "8.5.6",
-    "pptxgenjs": "4.0.0",
-    "prismjs": "1.30.0",
-    "sharp": "0.34.1",
-    "tailwindcss": "4.1.10",
-    "ts-node": "10.9.2",
-    "typescript": "5.8.3"
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "recharts": "2.8.0",
+    "framer-motion": "11.2.12",
+    "lucide-react": "0.378.0",
+    "tailwindcss": "4.1.10"
+  },
+  "devDependencies": {
+    "typescript": "5.8.3",
+    "vitest": "1.6.0",
+    "@vitejs/plugin-react": "4.3.2"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,6 @@
 import React from 'react';
+import FantasyMatchups from './pages/FantasyMatchups';
 
-/**
- * The root application component. This simple scaffold provides
- * a starting point for building your fantasy football analytics
- * dashboard. At runtime this component will be rendered by
- * React in the main entry point (src/main.tsx).
- */
 export default function App(): JSX.Element {
-  return (
-    <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
-      <h1 style={{ fontSize: '2rem', fontWeight: 'bold', marginBottom: '1rem' }}>
-        GridIron IQ
-      </h1>
-      <p>
-        Welcome! This repository has been set up with a basic React + Vite
-        configuration. You can start adding your fantasy football analytics
-        components here. Use Sleeper for league data and add additional
-        providers as needed for projections, injuries, and other metrics.
-      </p>
-    </div>
-  );
+  return <FantasyMatchups />;
 }

--- a/src/api/providers/interfaces.ts
+++ b/src/api/providers/interfaces.ts
@@ -1,0 +1,29 @@
+export interface ProviderBase {
+  readonly source: string;
+  readonly ttlMs: number;
+  readonly isEnabled: boolean;
+}
+
+export interface ProjectionProvider extends ProviderBase {
+  fetchWeekly(playerIds: string[], week: number): Promise<Record<string, number>>;
+}
+
+export interface InjuryProvider extends ProviderBase {
+  fetchInjuries(playerIds: string[]): Promise<Record<string, string>>;
+}
+
+export interface WeatherProvider extends ProviderBase {
+  fetchWeather(gameIds: string[]): Promise<Record<string, string>>;
+}
+
+export interface OddsProvider extends ProviderBase {
+  fetchOdds(gameIds: string[]): Promise<Record<string, { spread: number; total: number }>>;
+}
+
+export interface NewsProvider extends ProviderBase {
+  fetchNews(playerIds: string[]): Promise<Record<string, string>>;
+}
+
+export interface StatsProvider extends ProviderBase {
+  fetchStats(playerIds: string[], week: number): Promise<Record<string, unknown>>;
+}

--- a/src/api/providers/merge.ts
+++ b/src/api/providers/merge.ts
@@ -1,0 +1,20 @@
+import type { ProjectionProvider } from './interfaces';
+
+export async function mergeProjections<T extends { player_id: string }>(
+  players: T[],
+  provider: ProjectionProvider,
+  week: number,
+): Promise<(T & { projection?: number; source?: string })[]> {
+  if (!provider.isEnabled) return players;
+  try {
+    const ids = players.map((p) => p.player_id);
+    const proj = await provider.fetchWeekly(ids, week);
+    return players.map((p) => ({
+      ...p,
+      projection: proj[p.player_id],
+      source: provider.source,
+    }));
+  } catch {
+    return players;
+  }
+}

--- a/src/api/providers/mock.ts
+++ b/src/api/providers/mock.ts
@@ -1,0 +1,16 @@
+import type { ProjectionProvider } from './interfaces';
+
+const enabled = Boolean(import.meta.env.VITE_PROJECTIONS_ENABLED);
+
+export const MockProjectionProvider: ProjectionProvider = {
+  source: 'Mock',
+  ttlMs: 60 * 60 * 1000,
+  isEnabled: enabled,
+  async fetchWeekly(playerIds: string[], _week: number) {
+    const out: Record<string, number> = {};
+    playerIds.forEach((id, i) => {
+      out[id] = 10 + i;
+    });
+    return out;
+  },
+};

--- a/src/api/sleeper.ts
+++ b/src/api/sleeper.ts
@@ -1,0 +1,30 @@
+import type { League, Matchup, NFLState, Players, Roster, User } from '../types/sleeper';
+
+const BASE = 'https://api.sleeper.app/v1';
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Sleeper fetch failed: ${res.status}`);
+  return (await res.json()) as T;
+}
+
+export const SleeperApi = {
+  state(): Promise<NFLState> {
+    return fetchJson<NFLState>(`${BASE}/state/nfl`);
+  },
+  league(leagueId: string): Promise<League> {
+    return fetchJson<League>(`${BASE}/league/${leagueId}`);
+  },
+  users(leagueId: string): Promise<User[]> {
+    return fetchJson<User[]>(`${BASE}/league/${leagueId}/users`);
+  },
+  rosters(leagueId: string): Promise<Roster[]> {
+    return fetchJson<Roster[]>(`${BASE}/league/${leagueId}/rosters`);
+  },
+  matchups(leagueId: string, week: number): Promise<Matchup[]> {
+    return fetchJson<Matchup[]>(`${BASE}/league/${leagueId}/matchups/${week}`);
+  },
+  players(): Promise<Players> {
+    return fetchJson<Players>(`${BASE}/players/nfl`);
+  },
+};

--- a/src/components/FunMetrics.tsx
+++ b/src/components/FunMetrics.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export function FunMetrics() {
+  return (
+    <div className="p-4 text-center text-gray-500">
+      Fun metrics like the Hype Volatility Index and Luck Index will be
+      displayed here.
+    </div>
+  );
+}

--- a/src/components/LeagueRosters.tsx
+++ b/src/components/LeagueRosters.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import type { Players, Roster, User } from '../types/sleeper';
+import { SleeperApi } from '../api/sleeper';
+
+interface Props {
+  rosters: Roster[];
+  users: User[];
+}
+
+function fmtPlayer(id: string, players?: Players): string {
+  if (!players) return id;
+  if (/^[A-Z]{2,3}$/.test(id)) return `${id} D/ST`;
+  const p = players[id];
+  if (!p) return id;
+  const pos = p.position || p.fantasy_positions?.[0] || '';
+  const team = p.team ? ` (${p.team})` : '';
+  return `${p.full_name}${team} ${pos}`.trim();
+}
+
+export function LeagueRosters({ rosters, users }: Props) {
+  const [players, setPlayers] = useState<Players | null>(null);
+  const loadPlayers = async () => {
+    const p = await SleeperApi.players();
+    setPlayers(p);
+    localStorage.setItem('players_nfl', JSON.stringify({ t: Date.now(), p }));
+  };
+  const stored = localStorage.getItem('players_nfl');
+  if (!players && stored) {
+    try {
+      const obj = JSON.parse(stored);
+      if (Date.now() - obj.t < 24 * 60 * 60 * 1000) setPlayers(obj.p);
+    } catch {
+      /* ignore */
+    }
+  }
+  const userById = Object.fromEntries(users.map((u) => [u.user_id, u]));
+  return (
+    <div>
+      {!players && (
+        <button onClick={loadPlayers} className="mb-4 border px-2 py-1">
+          Load player names (~5MB)
+        </button>
+      )}
+      <div className="grid md:grid-cols-2 gap-4">
+        {rosters.map((r) => {
+          const owner = userById[r.owner_id];
+          const title =
+            r.metadata.team_name || owner?.display_name || `Roster #${r.roster_id}`;
+          return (
+            <div key={r.roster_id} className="border rounded p-2">
+              <div className="font-bold mb-2">{title}</div>
+              <div className="flex gap-4">
+                <div>
+                  <div className="font-semibold">Starters</div>
+                  <ul>
+                    {r.starters.map((id) => (
+                      <li key={id}>{fmtPlayer(id, players ?? undefined)}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <div className="font-semibold">Bench</div>
+                  <ul>
+                    {r.bench.map((id) => (
+                      <li key={id}>{fmtPlayer(id, players ?? undefined)}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MatchupChart.tsx
+++ b/src/components/MatchupChart.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from 'recharts';
+import { fmtHourLabel, hourLabelIndices } from '../utils/time';
+
+export interface MatchupSeries {
+  home: number[];
+  away: number[];
+}
+
+interface Props {
+  series: MatchupSeries;
+}
+
+const dataFromSeries = (series: MatchupSeries) => {
+  return series.home.map((h, i) => ({
+    i,
+    home: h,
+    away: series.away[i],
+  }));
+};
+
+export function MatchupChart({ series }: Props) {
+  const data = dataFromSeries(series);
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ left: 20, right: 20 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="i"
+          ticks={hourLabelIndices}
+          tickFormatter={fmtHourLabel}
+        />
+        <YAxis allowDecimals domain={[0, 'dataMax']} />
+        <Tooltip
+          labelFormatter={(v) => {
+            const hour = 12 + Math.floor(Number(v) / 6);
+            const minute = (Number(v) % 6) * 10;
+            const h = hour > 12 ? hour - 12 : hour;
+            const suffix = hour >= 12 ? 'PM' : 'AM';
+            return `${h}:${minute.toString().padStart(2, '0')} ${suffix} ET`;
+          }}
+        />
+        <Line type="monotone" dataKey="home" stroke="#1d4ed8" dot={false} />
+        <Line type="monotone" dataKey="away" stroke="#dc2626" dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/PlayerAnalytics.tsx
+++ b/src/components/PlayerAnalytics.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export function PlayerAnalytics() {
+  return (
+    <div className="p-4 text-center text-gray-500">
+      Player analytics coming soon. Integrate projections, injuries and more via
+      provider adapters.
+    </div>
+  );
+}

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import type { Matchup, Roster, User } from '../types/sleeper';
+
+interface Props {
+  matchups?: Matchup[] | null;
+  rosters?: Roster[] | null;
+  users?: User[] | null;
+}
+
+export function Scoreboard({ matchups, rosters, users }: Props) {
+  const safeMatchups = matchups ?? [];
+  const rosterById = Object.fromEntries((rosters ?? []).map((r) => [r.roster_id, r]));
+  const userById = Object.fromEntries((users ?? []).map((u) => [u.user_id, u]));
+  const grouped: Record<number, Matchup[]> = {};
+  safeMatchups.forEach((m) => {
+    grouped[m.matchup_id] = grouped[m.matchup_id] || [];
+    grouped[m.matchup_id].push(m);
+  });
+
+  const sets = Object.values(grouped);
+  if (sets.length === 0) {
+    return <div className="text-center text-gray-500">No matchups</div>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {sets.map(([a, b]) => {
+        if (!a || !b) return null;
+        const rosterA = rosterById[a.roster_id];
+        const rosterB = rosterById[b.roster_id];
+        const nameA =
+          rosterA?.metadata.team_name ||
+          userById[rosterA?.owner_id ?? '']?.display_name ||
+          `Roster ${a.roster_id}`;
+        const nameB =
+          rosterB?.metadata.team_name ||
+          userById[rosterB?.owner_id ?? '']?.display_name ||
+          `Roster ${b.roster_id}`;
+        return (
+          <div
+            key={a.matchup_id}
+            className="flex items-center justify-between rounded-lg border bg-white p-4 shadow-sm dark:bg-gray-800"
+          >
+            <div>
+              <div className="font-medium">{nameA}</div>
+              <div className="text-xl font-bold">{a.points.toFixed(1)}</div>
+            </div>
+            <div className="text-center text-sm text-gray-500">vs</div>
+            <div className="text-right">
+              <div className="font-medium">{nameB}</div>
+              <div className="text-xl font-bold">{b.points.toFixed(1)}</div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/TeamAnalytics.tsx
+++ b/src/components/TeamAnalytics.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export function TeamAnalytics() {
+  return (
+    <div className="p-4 text-center text-gray-500">
+      Team analytics coming soon. Pace, red-zone usage and more will live here.
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type Variant = 'default' | 'secondary' | 'outline';
+
+export function Badge({ variant = 'default', className = '', children, ...props }: React.HTMLAttributes<HTMLSpanElement> & { variant?: Variant }) {
+  let style = 'px-2 py-0.5 text-xs rounded';
+  if (variant === 'secondary') style += ' bg-gray-200 text-gray-800';
+  else if (variant === 'outline') style += ' border';
+  else style += ' bg-blue-600 text-white';
+  return (
+    <span className={`${style} ${className}`} {...props}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+type Variant = 'default' | 'outline' | 'ghost';
+
+export function Button({ variant = 'default', className = '', children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: Variant }) {
+  const base = 'px-3 py-1 rounded text-sm';
+  let style = '';
+  if (variant === 'outline') style = 'border';
+  else if (variant === 'ghost') style = 'bg-transparent';
+  else style = 'bg-blue-600 text-white';
+  const disabled = props.disabled ? 'opacity-50 cursor-not-allowed' : '';
+  return (
+    <button className={`${base} ${style} ${disabled} ${className}`} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export function Card({ className = '', children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`rounded-xl border bg-white ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({ className = '', children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`p-4 ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function CardTitle({ className = '', children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h3 className={`text-lg font-semibold ${className}`} {...props}>
+      {children}
+    </h3>
+  );
+}
+
+export function CardContent({ className = '', children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`p-4 pt-0 ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function Input({ className = '', ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <input className={`border rounded px-2 py-1 text-sm ${className}`} {...props} />;
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+type SelectProps = {
+  value: string;
+  onValueChange: (v: string) => void;
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function Select({ value, onValueChange, className = '', children }: SelectProps) {
+  let triggerClass = '';
+  const options: React.ReactNode[] = [];
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) return;
+    if (child.type === SelectTrigger) {
+      triggerClass = child.props.className || '';
+    } else if (child.type === SelectContent) {
+      React.Children.forEach(child.props.children, (item) => {
+        if (React.isValidElement(item) && item.type === SelectItem) {
+          options.push(item);
+        }
+      });
+    }
+  });
+  return (
+    <select className={`${triggerClass} ${className}`} value={value} onChange={(e) => onValueChange(e.target.value)}>
+      {options}
+    </select>
+  );
+}
+
+export function SelectTrigger({ children, className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={className} {...props}>{children}</div>;
+}
+
+export function SelectValue(_: { placeholder?: string }) {
+  return null;
+}
+
+export function SelectContent({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+export function SelectItem({ value, children }: { value: string; children: React.ReactNode }) {
+  return <option value={value}>{children}</option>;
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface TabsCtx {
+  value: string;
+  setValue: (v: string) => void;
+}
+
+const TabsContext = createContext<TabsCtx | undefined>(undefined);
+
+export function Tabs({ defaultValue, children, className = '' }: { defaultValue: string; children: React.ReactNode; className?: string }) {
+  const [value, setValue] = useState(defaultValue);
+  return (
+    <div className={className}>
+      <TabsContext.Provider value={{ value, setValue }}>{children}</TabsContext.Provider>
+    </div>
+  );
+}
+
+export function TabsList({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return <div className={className}>{children}</div>;
+}
+
+export function TabsTrigger({ value, children, className = '' }: { value: string; children: React.ReactNode; className?: string }) {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error('TabsTrigger must be used within Tabs');
+  const active = ctx.value === value;
+  return (
+    <button
+      className={`${className} ${active ? 'font-bold' : ''}`}
+      onClick={() => ctx.setValue(value)}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TabsContent({ value, children, className = '' }: { value: string; children: React.ReactNode; className?: string }) {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error('TabsContent must be used within Tabs');
+  if (ctx.value !== value) return null;
+  return <div className={className}>{children}</div>;
+}

--- a/src/hooks/useSleeperWeek.ts
+++ b/src/hooks/useSleeperWeek.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import { SleeperApi } from '../api/sleeper';
+
+export function useSleeperWeek() {
+  const [week, setWeek] = useState<number | null>(null);
+  useEffect(() => {
+    SleeperApi.state()
+      .then((s) => {
+        const w = s.display_week ?? s.week ?? s.leg;
+        setWeek(w);
+      })
+      .catch(() => setWeek(null));
+  }, []);
+  return week;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { SleeperApi } from '../api/sleeper';
+import type { League, Matchup, Roster, User } from '../types/sleeper';
+import { useSleeperWeek } from '../hooks/useSleeperWeek';
+import { Scoreboard } from '../components/Scoreboard';
+import { LeagueRosters } from '../components/LeagueRosters';
+import { MatchupChart } from '../components/MatchupChart';
+import { PlayerAnalytics } from '../components/PlayerAnalytics';
+import { TeamAnalytics } from '../components/TeamAnalytics';
+import { FunMetrics } from '../components/FunMetrics';
+import { generateSeries } from '../utils/series';
+
+const DEFAULT_LEAGUE = '1236033733312651264';
+
+export function Dashboard() {
+  const autoWeek = useSleeperWeek();
+  const [leagueId, setLeagueId] = useState(DEFAULT_LEAGUE);
+  const [week, setWeek] = useState<number>(1);
+  const [league, setLeague] = useState<League | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
+  const [rosters, setRosters] = useState<Roster[]>([]);
+  const [matchups, setMatchups] = useState<Matchup[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [tab, setTab] = useState<'matchups' | 'league' | 'players' | 'teams' | 'fun'>('matchups');
+  const [selected, setSelected] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (autoWeek && week === 1) setWeek(autoWeek);
+  }, [autoWeek, week]);
+
+  async function sync() {
+    setLoading(true);
+    try {
+      const [lg, us, rs, ms] = await Promise.all([
+        SleeperApi.league(leagueId),
+        SleeperApi.users(leagueId),
+        SleeperApi.rosters(leagueId),
+        SleeperApi.matchups(leagueId, week),
+      ]);
+      setLeague(lg);
+      setUsers(us);
+      setRosters(rs);
+      setMatchups(ms);
+      setSelected(ms[0]?.matchup_id ?? null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const grouped = matchups.filter((m) => m.matchup_id === selected);
+  const series = grouped.length === 2
+    ? {
+        home: generateSeries(`${grouped[0].roster_id}-${grouped[1].roster_id}-t1`, grouped[0].points),
+        away: generateSeries(`${grouped[0].roster_id}-${grouped[1].roster_id}-t2`, grouped[1].points),
+      }
+    : { home: [], away: [] };
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4">
+      <header className="flex items-center gap-2">
+        <input
+          value={leagueId}
+          onChange={(e) => setLeagueId(e.target.value)}
+          className="w-48 rounded border px-2 py-1"
+        />
+        <select
+          value={week}
+          onChange={(e) => setWeek(Number(e.target.value))}
+          className="rounded border px-2 py-1"
+        >
+          {Array.from({ length: 18 }, (_, i) => i + 1).map((w) => (
+            <option key={w}>{w}</option>
+          ))}
+        </select>
+        <button
+          onClick={sync}
+          disabled={loading}
+          className="rounded border bg-blue-600 px-3 py-1 text-white disabled:opacity-50"
+        >
+          {loading ? 'Syncing...' : 'Sync Sleeper'}
+        </button>
+        {league && <div className="ml-auto font-bold">{league.name}</div>}
+      </header>
+      <nav className="flex flex-wrap gap-4 border-b pb-2">
+        <button onClick={() => setTab('matchups')} className={tab === 'matchups' ? 'font-bold' : ''}>
+          Matchups
+        </button>
+        <button onClick={() => setTab('league')} className={tab === 'league' ? 'font-bold' : ''}>
+          League
+        </button>
+        <button onClick={() => setTab('players')} className={tab === 'players' ? 'font-bold' : ''}>
+          Player Analytics
+        </button>
+        <button onClick={() => setTab('teams')} className={tab === 'teams' ? 'font-bold' : ''}>
+          Team Analytics
+        </button>
+        <button onClick={() => setTab('fun')} className={tab === 'fun' ? 'font-bold' : ''}>
+          Fun Metrics
+        </button>
+      </nav>
+      {tab === 'matchups' && matchups.length > 0 && (
+        <div className="space-y-4">
+          {selected && series.home.length === 61 && <MatchupChart series={series} />}
+          <Scoreboard matchups={matchups} rosters={rosters} users={users} />
+        </div>
+      )}
+      {tab === 'league' && <LeagueRosters rosters={rosters} users={users} />}
+      {tab === 'players' && <PlayerAnalytics />}
+      {tab === 'teams' && <TeamAnalytics />}
+      {tab === 'fun' && <FunMetrics />}
+    </div>
+  );
+}

--- a/src/pages/FantasyMatchups.tsx
+++ b/src/pages/FantasyMatchups.tsx
@@ -1,0 +1,909 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { RefreshCcw, Trophy, Timer } from "lucide-react";
+import { motion } from "framer-motion";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+  Brush,
+  BarChart,
+  Bar,
+} from "recharts";
+
+/**
+ * Fantasy Matchups – Scoreboard + Stock‑style Time Series (Top Section)
+ * --------------------------------------------------------------------
+ * Update per feedback:
+ * - Smooth **monotone** lines
+ * - Explicit **two different colors** for the teams
+ * - X‑axis shows **hour labels including 12p** (12p → 10p) with dotted 10‑min grid
+ */
+
+// ---------- Types ----------
+export type Matchup = {
+  week: number;
+  team1: string;
+  points1: number;
+  team2: string;
+  points2: number;
+  status?: "LIVE" | "FINAL";
+};
+
+// ---------- Theme colors for lines ----------
+const TEAM_COLORS = ["#2563eb", "#dc2626"]; // blue-600, red-600
+
+// ---------- Utility helpers ----------
+function pct(a: number, b: number) {
+  const total = a + b;
+  if (total <= 0) return 0.5;
+  return a / total;
+}
+function winner(m: Matchup) {
+  if (m.points1 === m.points2) return "Tied";
+  return m.points1 > m.points2 ? m.team1 : m.team2;
+}
+function margin(m: Matchup) {
+  return Math.abs(m.points1 - m.points2);
+}
+function total(m: Matchup) {
+  return m.points1 + m.points2;
+}
+
+// ---------- Time axis (12:00 PM ET → 10:00 PM ET, inclusive) ----------
+const TICKS_PER_HOUR = 6; // 10‑minute increments
+const START_HOUR_ET = 12; // 12p
+const END_HOUR_ET = 22; // 10p
+const TOTAL_TICKS = (END_HOUR_ET - START_HOUR_ET) * TICKS_PER_HOUR + 1; // 61 points (inclusive)
+
+const allTickIndices = Array.from({ length: TOTAL_TICKS }, (_, i) => i); // 0..60
+// Show **hour labels including 12p** → 12p,1p,...,10p
+const hourLabelIndices = Array.from({ length: 11 }, (_, i) => i * TICKS_PER_HOUR); // 0,6,12,...,60
+
+function fmtHourLabel(idx: number) {
+  const minutes = idx * 10;
+  const hour24 = START_HOUR_ET + Math.floor(minutes / 60);
+  const hour12 = ((hour24 + 11) % 12) + 1;
+  const ampm = hour24 >= 12 ? "p" : "a";
+  return `${hour12}${ampm}`; // e.g., 12p, 1p, 2p ... 10p
+}
+
+// ---------- Seeded RNG so a matchup renders the same series every time ----------
+function toSeed(str: string) {
+  let h = 2166136261 >>> 0; // FNV‑1a
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+function mulberry32(a: number) {
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ---------- Dummy series generator (sums to final & stable per matchup) ----------
+function genCumulativeSeries(finalPts: number, seedKey: string, ticks: number = TOTAL_TICKS) {
+  const rng = mulberry32(toSeed(seedKey));
+  // Build non‑negative increments with many zeros, then scale so sum == finalPts.
+  const incs = Array(ticks).fill(0);
+  for (let i = 1; i < ticks; i++) {
+    // ~55% chance of no scoring at a 10‑min slice, else a small burst
+    incs[i] = rng() < 0.55 ? 0 : 0.4 + rng() * 3.2; // 0.4–3.6 pre‑scale
+  }
+  // a few spikes to create visible swings
+  for (let k = 0; k < 5; k++) {
+    const j = 1 + Math.floor(rng() * (ticks - 1));
+    incs[j] += 2 + rng() * 6;
+  }
+  const weightSum = incs.reduce((a, b) => a + b, 0);
+  if (weightSum === 0) {
+    incs[ticks - 1] = finalPts;
+  } else {
+    const scale = finalPts / weightSum;
+    for (let i = 1; i < ticks; i++) incs[i] = +(incs[i] * scale).toFixed(3);
+  }
+  // cumulative with 0.1 rounding & exact final fix
+  const series: number[] = Array(ticks).fill(0);
+  let cum = 0;
+  for (let i = 1; i < ticks; i++) {
+    cum += incs[i];
+    series[i] = +cum.toFixed(1);
+  }
+  const delta = +(finalPts - series[ticks - 1]).toFixed(1);
+  if (Math.abs(delta) > 0) series[ticks - 1] = +(series[ticks - 1] + delta).toFixed(1);
+  for (let i = 1; i < ticks; i++) if (series[i] < series[i - 1]) series[i] = series[i - 1];
+  return series;
+}
+
+function maskFuture(series: (number | null)[], upToIdx: number) {
+  return series.map((v, i) => (i <= upToIdx ? v : null));
+}
+
+// ---------- Simple in-app test helpers ----------
+// Existing tests kept; additional tests appended below.
+type TestResult = { name: string; ok: boolean; details?: string };
+function runTestsForMatchup(m: Matchup): TestResult[] {
+  const s1 = genCumulativeSeries(m.points1, `${m.team1}-${m.team2}-t1`);
+  const s2 = genCumulativeSeries(m.points2, `${m.team1}-${m.team2}-t2`);
+  const tests: TestResult[] = [];
+  // Original tests (unchanged)
+  tests.push({
+    name: `${m.team1} final equals ${m.points1}`,
+    ok: Math.abs(s1[s1.length - 1] - m.points1) < 1e-9,
+    details: `got ${s1[s1.length - 1]}`,
+  });
+  tests.push({
+    name: `${m.team2} final equals ${m.points2}`,
+    ok: Math.abs(s2[s2.length - 1] - m.points2) < 1e-9,
+    details: `got ${s2[s2.length - 1]}`,
+  });
+  tests.push({ name: `${m.team1} non-decreasing`, ok: s1.every((v, i) => i === 0 || v >= s1[i - 1]) });
+  tests.push({ name: `${m.team2} non-decreasing`, ok: s2.every((v, i) => i === 0 || v >= s2[i - 1]) });
+  // New tests
+  tests.push({ name: `${m.team1} has 61 points`, ok: s1.length === TOTAL_TICKS });
+  tests.push({ name: `${m.team2} has 61 points`, ok: s2.length === TOTAL_TICKS });
+  tests.push({ name: `${m.team1} starts at 0`, ok: s1[0] === 0 });
+  tests.push({ name: `${m.team2} starts at 0`, ok: s2[0] === 0 });
+  return tests;
+}
+
+function runGlobalTests(): TestResult[] {
+  const t: TestResult[] = [];
+  t.push({ name: "Hour labels count is 11", ok: hourLabelIndices.length === 11, details: String(hourLabelIndices.length) });
+  t.push({ name: "First label index is 0 (12p)", ok: hourLabelIndices[0] === 0, details: String(hourLabelIndices[0]) });
+  t.push({ name: "Last label index is 60 (10p)", ok: hourLabelIndices[hourLabelIndices.length - 1] === 60, details: String(hourLabelIndices[hourLabelIndices.length - 1]) });
+  t.push({ name: "fmtHourLabel(0) is 12p", ok: fmtHourLabel(0) === "12p", details: fmtHourLabel(0) });
+  t.push({ name: "fmtHourLabel(60) is 10p", ok: fmtHourLabel(60) === "10p", details: fmtHourLabel(60) });
+  const masked = maskFuture([0, 1, 2] as unknown as (number | null)[], 1);
+  t.push({ name: "maskFuture nulls future", ok: masked[2] === null, details: JSON.stringify(masked) });
+  // New: fmtPos behavior
+  const mockDict: PlayersDict = {
+    X1: { player_id: 'X1', full_name: 'Tester One', position: 'WR', team: 'BUF' },
+    X2: { player_id: 'X2', full_name: 'Tester Two', fantasy_positions: ['RB'], team: 'SF' },
+  };
+  t.push({ name: 'fmtPos prefers position', ok: fmtPos('X1', mockDict) === 'WR', details: fmtPos('X1', mockDict) });
+  t.push({ name: 'fmtPos falls back to fantasy_positions[0]', ok: fmtPos('X2', mockDict) === 'RB', details: fmtPos('X2', mockDict) });
+  return t;
+}
+
+// ---------- Sleeper sync helpers ----------
+const SLEEPER_API = "https://api.sleeper.app/v1";
+
+// Docs used: /state/nfl, /league, /users, /rosters, /matchups/{week}, /players/nfl
+
+type SleeperUser = { user_id: string; display_name: string; username?: string; avatar?: string; metadata?: Record<string, any> };
+type SleeperRoster = { roster_id: number; owner_id: string; starters?: string[]; players?: string[]; reserve?: string[]; metadata?: Record<string, any> };
+type SleeperMatchup = { matchup_id: number; roster_id: number; points: number; starters?: string[]; players?: string[] };
+type SleeperLeague = { league_id: string; name: string; season: string; season_type: string; total_rosters: number; scoring_settings?: Record<string, any>; roster_positions?: string[] };
+
+type NFLState = { display_week?: number; week?: number; leg?: number };
+
+type SleeperPlayer = { player_id: string; full_name?: string; first_name?: string; last_name?: string; team?: string; position?: string; fantasy_positions?: string[] };
+type PlayersDict = Record<string, SleeperPlayer>;
+
+async function fetchJSON<T>(url: string): Promise<T> {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`HTTP ${r.status} for ${url}`);
+  return r.json();
+}
+
+async function getSleeperWeekAuto(): Promise<number> {
+  const s = await fetchJSON<NFLState>(`${SLEEPER_API}/state/nfl`);
+  return (s.display_week ?? s.week ?? s.leg ?? 1) as number;
+}
+
+function rosterDisplayName(r: SleeperRoster | undefined, usersById: Map<string, SleeperUser>): string {
+  const metaName = (r?.metadata?.team_name || r?.metadata?.name || r?.metadata?.nickname) as string | undefined;
+  const ownerName = r?.owner_id ? usersById.get(r.owner_id)?.display_name : undefined;
+  return (metaName && metaName.trim()) || ownerName || (r ? `Roster ${r.roster_id}` : "Unknown");
+}
+
+function buildPairs(week: number, users: SleeperUser[], rosters: SleeperRoster[], matchups: SleeperMatchup[]): Matchup[] {
+  const usersById = new Map(users.map((u) => [u.user_id, u] as const));
+  const rostersById = new Map(rosters.map((r) => [r.roster_id, r] as const));
+  const byMatchup = new Map<number, SleeperMatchup[]>();
+  for (const m of matchups) {
+    if (!byMatchup.has(m.matchup_id)) byMatchup.set(m.matchup_id, []);
+    byMatchup.get(m.matchup_id)!.push(m);
+  }
+  const fix = (x: number) => Math.round(((x ?? 0) as number) * 10) / 10;
+  const pairs: Matchup[] = [];
+  for (const [, arr] of byMatchup.entries()) {
+    if (arr.length >= 2) {
+      const a = arr[0];
+      const b = arr[1];
+      const ra = rostersById.get(a.roster_id);
+      const rb = rostersById.get(b.roster_id);
+      pairs.push({
+        week,
+        team1: rosterDisplayName(ra, usersById),
+        points1: fix(a.points),
+        team2: rosterDisplayName(rb, usersById),
+        points2: fix(b.points),
+        status: "LIVE",
+      });
+    }
+  }
+  pairs.sort((m1, m2) => (m1.team1 + m1.team2).localeCompare(m2.team1 + m2.team2));
+  return pairs;
+}
+
+async function fetchPlayersDict(force = false): Promise<PlayersDict> {
+  const KEY = "sleeper_players_nfl_v1";
+  const TSKEY = "sleeper_players_nfl_v1_ts";
+  try {
+    if (!force) {
+      const cached = localStorage.getItem(KEY);
+      const ts = localStorage.getItem(TSKEY);
+      if (cached && ts) {
+        const ageHrs = (Date.now() - parseInt(ts)) / 36e5;
+        if (ageHrs < 24) return JSON.parse(cached);
+      }
+    }
+  } catch {}
+  const dict = await fetchJSON<PlayersDict>(`${SLEEPER_API}/players/nfl`);
+  try {
+    localStorage.setItem(KEY, JSON.stringify(dict));
+    localStorage.setItem(TSKEY, String(Date.now()));
+  } catch {}
+  return dict;
+}
+
+async function fetchLeagueBundle(leagueId: string, week: number) {
+  const [league, users, rosters, matchups] = await Promise.all([
+    fetchJSON<SleeperLeague>(`${SLEEPER_API}/league/${leagueId}`),
+    fetchJSON<SleeperUser[]>(`${SLEEPER_API}/league/${leagueId}/users`),
+    fetchJSON<SleeperRoster[]>(`${SLEEPER_API}/league/${leagueId}/rosters`),
+    fetchJSON<SleeperMatchup[]>(`${SLEEPER_API}/league/${leagueId}/matchups/${week}`),
+  ]);
+  return { league, users, rosters, matchups };
+}
+
+export default function FantasyMatchups() {
+  const [leagueId, setLeagueId] = useState<string>("1236033733312651264");
+  const [week, setWeek] = useState<number>(1);
+  const [sortBy, setSortBy] = useState<"margin" | "total">("margin");
+  const [loading, setLoading] = useState<boolean>(false);
+  const [data, setData] = useState<Matchup[]>([]);
+  const [leagueMeta, setLeagueMeta] = useState<SleeperLeague | null>(null);
+  const [leagueUsers, setLeagueUsers] = useState<SleeperUser[]>([]);
+  const [leagueRosters, setLeagueRosters] = useState<SleeperRoster[]>([]);
+  const [playersDict, setPlayersDict] = useState<PlayersDict | null>(null);
+  const [playersStatus, setPlayersStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+
+  // Top time‑series state
+  const [selectedMatchupIdx, setSelectedMatchupIdx] = useState<number>(0);
+  const [curIdx, setCurIdx] = useState<number>(0);
+  const [series1, setSeries1] = useState<number[]>(Array(TOTAL_TICKS).fill(0));
+  const [series2, setSeries2] = useState<number[]>(Array(TOTAL_TICKS).fill(0));
+  const [autoRefresh, setAutoRefresh] = useState<boolean>(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Self-test state & runner (Tools tab)
+  const [testResults, setTestResults] = useState<TestResult[] | null>(null);
+  const runAllTests = () => {
+    const results = [
+      ...data.flatMap(runTestsForMatchup),
+      ...runGlobalTests(),
+    ];
+    setTestResults(results);
+    const summary = results.map((r) => `${r.ok ? "✔" : "✘"} ${r.name}${r.details ? ` (${r.details})` : ""}`).join("\n");
+    console.log("[Self-tests]", "\n" + summary);
+  };
+
+  // Rebuild series when matchup changes
+  useEffect(() => {
+    const m = data[selectedMatchupIdx];
+    if (!m) return;
+    setSeries1(genCumulativeSeries(m.points1, `${m.team1}-${m.team2}-t1`));
+    setSeries2(genCumulativeSeries(m.points2, `${m.team1}-${m.team2}-t2`));
+    setCurIdx(TOTAL_TICKS - 1);
+  }, [selectedMatchupIdx, data]);
+
+  // Auto-detect current display week from Sleeper state on mount
+  useEffect(() => {
+    (async () => {
+      try {
+        const auto = await getSleeperWeekAuto();
+        if (Number.isFinite(auto)) setWeek(auto);
+      } catch (e) {
+        console.warn('Auto-week failed', e);
+      }
+    })();
+  }, []);
+
+  // Auto‑advance every 10 minutes (simulated)
+  useEffect(() => {
+    if (autoRefresh) {
+      intervalRef.current = setInterval(() => stepForward(), 600000);
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [autoRefresh]);
+
+  function stepForward() {
+    setCurIdx((prev) => Math.min(prev + 1, TOTAL_TICKS - 1));
+  }
+  function resetDay() {
+    const m = data[selectedMatchupIdx] ?? data[0];
+    if (!m) return;
+    setSeries1(genCumulativeSeries(m.points1, `${m.team1}-${m.team2}-t1`));
+    setSeries2(genCumulativeSeries(m.points2, `${m.team1}-${m.team2}-t2`));
+    setCurIdx(0);
+  }
+
+  // Visible (masked) line data
+  const selectedMatchup = data[selectedMatchupIdx] ?? { week, team1: "Team 1", points1: 0, team2: "Team 2", points2: 0, status: "LIVE" as const };
+  const masked1 = useMemo(() => (curIdx >= TOTAL_TICKS - 1 ? series1 : maskFuture(series1, curIdx)), [series1, curIdx]);
+  const masked2 = useMemo(() => (curIdx >= TOTAL_TICKS - 1 ? series2 : maskFuture(series2, curIdx)), [series2, curIdx]);
+
+  const lineRows = useMemo(() => {
+    return allTickIndices.map((i) => ({ idx: i, [selectedMatchup.team1]: masked1[i], [selectedMatchup.team2]: masked2[i] }));
+  }, [masked1, masked2, selectedMatchup]);
+
+  // Scoreboard grid + margin chart
+  const sorted = useMemo(() => {
+    const copy = [...data];
+    if (sortBy === "margin") copy.sort((a, b) => margin(b) - margin(a));
+    else copy.sort((a, b) => total(b) - total(a));
+    return copy;
+  }, [data, sortBy]);
+
+  const marginChartData = useMemo(
+    () =>
+      sorted.map((m, i) => ({ id: i + 1, matchup: `${m.team1} vs ${m.team2}`, margin: margin(m) })),
+    [sorted]
+  );
+
+  async function handleRefresh() {
+    setLoading(true);
+    try {
+      // Determine active week via /state/nfl (display_week preferred)
+      let activeWeek = week;
+      try {
+        const auto = await getSleeperWeekAuto();
+        if (Number.isFinite(auto)) { activeWeek = auto; setWeek(auto); }
+      } catch (e) { console.warn('state/nfl failed; using selected week', e); }
+
+      if (leagueId && leagueId.trim()) {
+        const { league, users, rosters, matchups } = await fetchLeagueBundle(leagueId.trim(), activeWeek);
+        setLeagueMeta(league);
+        setLeagueUsers(users);
+        setLeagueRosters(rosters);
+        const pairs = buildPairs(activeWeek, users, rosters, matchups);
+        if (pairs.length > 0) {
+          setData(pairs);
+          setSelectedMatchupIdx(0);
+          the rest ...
+    const m = data[selectedMatchupIdx] ?? data[0];
+    if (!m) return;
+    setSeries1(genCumulativeSeries(m.points1, `${m.team1}-${m.team2}-t1`));
+    setSeries2(genCumulativeSeries(m.points2, `${m.team1}-${m.team2}-t2`));
+    setCurIdx(0);
+  }
+
+  // Visible (masked) line data
+  const selectedMatchup = data[selectedMatchupIdx] ?? { week, team1: "Team 1", points1: 0, team2: "Team 2", points2: 0, status: "LIVE" as const };
+  const masked1 = useMemo(() => (curIdx >= TOTAL_TICKS - 1 ? series1 : maskFuture(series1, curIdx)), [series1, curIdx]);
+  const masked2 = useMemo(() => (curIdx >= TOTAL_TICKS - 1 ? series2 : maskFuture(series2, curIdx)), [series2, curIdx]);
+
+  const lineRows = useMemo(() => {
+    return allTickIndices.map((i) => ({ idx: i, [selectedMatchup.team1]: masked1[i], [selectedMatchup.team2]: masked2[i] }));
+  }, [masked1, masked2, selectedMatchup]);
+
+  // Scoreboard grid + margin chart
+  const sorted = useMemo(() => {
+    const copy = [...data];
+    if (sortBy === "margin") copy.sort((a, b) => margin(b) - margin(a));
+    else copy.sort((a, b) => total(b) - total(a));
+    return copy;
+  }, [data, sortBy]);
+
+  const marginChartData = useMemo(
+    () =>
+      sorted.map((m, i) => ({ id: i + 1, matchup: `${m.team1} vs ${m.team2}`, margin: margin(m) })),
+    [sorted]
+  );
+
+  async function handleRefresh() {
+    setLoading(true);
+    try {
+      // Determine active week via /state/nfl (display_week preferred)
+      let activeWeek = week;
+      try {
+        const auto = await getSleeperWeekAuto();
+        if (Number.isFinite(auto)) { activeWeek = auto; setWeek(auto); }
+      } catch (e) { console.warn('state/nfl failed; using selected week', e); }
+
+      if (leagueId && leagueId.trim()) {
+        const { league, users, rosters, matchups } = await fetchLeagueBundle(leagueId.trim(), activeWeek);
+        setLeagueMeta(league);
+        setLeagueUsers(users);
+        setLeagueRosters(rosters);
+        const pairs = buildPairs(activeWeek, users, rosters, matchups);
+        if (pairs.length > 0) {
+          setData(pairs);
+          setSelectedMatchupIdx(0);
+          const m = pairs[0];
+          setSeries1(genCumulativeSeries(m.points1, `${m.team1}-${m.team2}-t1`));
+          setSeries2(genCumulativeSeries(m.points2, `${m.team1}-${m.team2}-t2`));
+          setCurIdx(TOTAL_TICKS - 1);
+        } else {
+          setData([]);
+        }
+      } else {
+        setData([]);
+      }
+    } catch (e: any) {
+      console.error(e);
+      alert(`Sleeper sync failed: ${e?.message ?? e}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadPlayers(force = false) {
+    try {
+      setPlayersStatus('loading');
+      const dict = await fetchPlayersDict(force);
+      setPlayersDict(dict);
+      setPlayersStatus('ready');
+    } catch (e) {
+      console.error(e);
+      setPlayersStatus('error');
+    }
+  }
+
+  return (
+    <div className="min-h-screen w-full bg-background text-foreground p-6">
+      <div className="max-w-6xl mx-auto space-y-6">
+        {/* Global Header */}
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Gridiron IQ</h1>
+            <p className="text-sm text-muted-foreground">Analytics-first fantasy dashboard • Week {week}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Input
+              placeholder="Sleeper League ID"
+              value={leagueId}
+              onChange={(e) => setLeagueId(e.target.value)}
+              className="w-56"
+            />
+            <Select value={String(week)} onValueChange={(v) => setWeek(parseInt(v))}>
+              <SelectTrigger className="w-[120px]">
+                <SelectValue placeholder="Week" />
+              </SelectTrigger>
+              <SelectContent>
+                {Array.from({ length: 18 }).map((_, i) => (
+                  <SelectItem key={i + 1} value={String(i + 1)}>
+                    Week {i + 1}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button onClick={handleRefresh} disabled={loading} className="gap-2">
+              <RefreshCcw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+              {loading ? "Refreshing" : "Sync Sleeper"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Primary navigation tabs */}
+        <Tabs defaultValue="matchups" className="w-full">
+          <TabsList className="grid grid-cols-6 gap-2">
+            <TabsTrigger value="matchups">Matchups</TabsTrigger>
+            <TabsTrigger value="players">Player Analytics</TabsTrigger>
+            <TabsTrigger value="teams">Team Analytics</TabsTrigger>
+            <TabsTrigger value="fun">Fun Metrics</TabsTrigger>
+            <TabsTrigger value="league">League</TabsTrigger>
+            <TabsTrigger value="tools">Tools</TabsTrigger>
+          </TabsList>
+
+          {/* MATCHUPS TAB */}
+          <TabsContent value="matchups" className="space-y-6">
+            {/* TOP: Stock‑style time series */}
+            <Card className="rounded-2xl border">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">Performance Over Time (12:00 PM – 10:00 PM ET)</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground">Matchup</span>
+                    <Select value={String(selectedMatchupIdx)} onValueChange={(v) => setSelectedMatchupIdx(parseInt(v))}>
+                      <SelectTrigger className="w-[260px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {data.map((m, i) => (
+                          <SelectItem key={`${m.team1}-${m.team2}-${i}`} value={String(i)}>
+                            {m.team1} vs {m.team2}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="ml-auto flex items-center gap-2">
+                    <Button variant={autoRefresh ? "default" : "outline"} onClick={() => setAutoRefresh((v) => !v)}>
+                      {autoRefresh ? "Auto‑refresh: ON" : "Auto‑refresh: OFF"}
+                    </Button>
+                    <Button variant="outline" onClick={stepForward}>Simulate next 10‑min</Button>
+                    <Button variant="ghost" onClick={resetDay}>Reset day</Button>
+                  </div>
+                </div>
+
+                <div className="w-full h-[380px]">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={lineRows} margin={{ top: 8, right: 16, left: 8, bottom: 0 }}>
+                      {/* full 10‑min grid lines */}
+                      <CartesianGrid vertical strokeDasharray="3 3" />
+                      {/* hidden axis driving grid every 10 min */}
+                      <XAxis xAxisId="grid" dataKey="idx" ticks={allTickIndices} hide />
+                      {/* visible hourly labels including 12p */}
+                      <XAxis
+                        xAxisId="labels"
+                        dataKey="idx"
+                        ticks={hourLabelIndices}
+                        tickFormatter={fmtHourLabel}
+                        tick={{ fontSize: 12 }}
+                        interval={0}
+                        height={28}
+                      />
+                      <YAxis domain={[0, 'auto']} tick={{ fontSize: 12 }} label={{ value: "Pts", angle: -90, position: "insideLeft" }} allowDecimals />
+                      <Tooltip
+                        formatter={(v: number) => [Number(v).toFixed(1), "Pts"]}
+                        labelFormatter={(i) => {
+                          const minutes = (i as number) * 10;
+                          const hour24 = START_HOUR_ET + Math.floor(minutes / 60);
+                          const mins = minutes % 60;
+                          const h12 = ((hour24 + 11) % 12) + 1;
+                          const mm = mins.toString().padStart(2, "0");
+                          const ampm = hour24 >= 12 ? "PM" : "AM";
+                          return `${h12}:${mm} ${ampm} ET`;
+                        }}
+                      />
+                      <Legend wrapperStyle={{ fontSize: 12 }} />
+
+                      {/* Smooth lines with explicit colors */}
+                      <Line type="monotone" dataKey={selectedMatchup.team1} dot={{ r: 3, stroke: TEAM_COLORS[0], fill: TEAM_COLORS[0] }} activeDot={{ r: 5 }} strokeWidth={2} stroke={TEAM_COLORS[0]} />
+                      <Line type="monotone" dataKey={selectedMatchup.team2} dot={{ r: 3, stroke: TEAM_COLORS[1], fill: TEAM_COLORS[1] }} activeDot={{ r: 5 }} strokeWidth={2} stroke={TEAM_COLORS[1]} />
+
+                      <Brush dataKey="idx" height={24} travellerWidth={8} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+
+                <p className="text-xs text-muted-foreground">
+                  Each point represents the cumulative score at a 10‑minute pull. The last point (10:00 PM ET) equals the final score for each team.
+                </p>
+              </CardContent>
+            </Card>
+
+            {/* Scoreboard grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {sorted.map((m, idx) => {
+                const w = winner(m);
+                return (
+                  <motion.div
+                    key={`${m.team1}-${m.team2}-${idx}`}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.25, delay: idx * 0.03 }}
+                  >
+                    <Card className="rounded-2xl shadow-sm border">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-base flex items-center justify-between">
+                          <span className="truncate mr-2">{m.team1} <span className="text-muted-foreground">vs</span> {m.team2}</span>
+                          <div className="flex items-center gap-2">
+                            <Badge variant={m.status === "FINAL" ? "secondary" : "default"} className="gap-1">
+                              {m.status === "FINAL" ? <Trophy className="w-3 h-3" /> : <Timer className="w-3 h-3" />}
+                              {m.status}
+                            </Badge>
+                            {m.status === "FINAL" && winner(m) !== "Tied" && (
+                              <Badge className="gap-1" variant="outline">
+                                <Trophy className="w-3 h-3" /> {winner(m)}
+                              </Badge>
+                            )}
+                          </div>
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="space-y-3">
+                        {/* Mini lead bar */}
+                        <div className="space-y-1">
+                          <div className="flex justify-between text-xs">
+                            <span className="truncate pr-2">{m.team1} • {m.points1.toFixed(1)}</span>
+                            <span className="truncate pl-2 text-right">{m.points2.toFixed(1)} • {m.team2}</span>
+                          </div>
+                          <div className="w-full h-3 rounded-full bg-muted overflow-hidden">
+                            <div className={`h-full ${m.points1 >= m.points2 ? "bg-primary" : "bg-primary/40"}`} style={{ width: `${pct(m.points1, m.points2) * 100}%` }} />
+                            <div className={`h-full -mt-3 ${m.points2 > m.points1 ? "bg-primary" : "bg-primary/40"}`} style={{ width: `${(1 - pct(m.points1, m.points2)) * 100}%` }} />
+                          </div>
+                          <div className="flex justify-between text-xs text-muted-foreground">
+                            <span>Total: {(m.points1 + m.points2).toFixed(1)}</span>
+                            <span>Margin: {Math.abs(m.points1 - m.points2).toFixed(1)}</span>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                );
+              })}
+            </div>
+          </TabsContent>
+
+          {/* PLAYER ANALYTICS */}
+          <TabsContent value="players" className="space-y-4">
+            <Card className="rounded-2xl border">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">Player Analytics (prototype)</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                {/* Consistency vs Ceiling */}
+                <div className="w-full h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={[{n:'WR A',c:14,ce:28},{n:'WR B',c:9,ce:22},{n:'WR C',c:12,ce:18},{n:'WR D',c:8,ce:30}]}>                    
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis dataKey="n" />
+                      <YAxis label={{ value: 'Pts', angle: -90, position: 'insideLeft' }} />
+                      <Tooltip />
+                      <Legend />
+                      <Bar dataKey="c" name="Median (Consistency)" />
+                      <Bar dataKey="ce" name="90th (Ceiling)" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+
+                {/* Usage/role trend (dummy) */}
+                <div className="w-full h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={[{w:1,rr:70,ts:18},{w:2,rr:74,ts:20},{w:3,rr:80,ts:24},{w:4,rr:76,ts:23},{w:5,rr:82,ts:27}] }>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis dataKey="w" label={{ value: 'Week', position: 'insideBottom', dy: 8 }} />
+                      <YAxis yAxisId="left" label={{ value: 'Routes %', angle: -90, position: 'insideLeft' }} />
+                      <YAxis yAxisId="right" orientation="right" label={{ value: 'Target %', angle: -90, position: 'insideRight' }} />
+                      <Tooltip />
+                      <Legend />
+                      <Line yAxisId="left" type="monotone" dataKey="rr" name="Routes Run %" />
+                      <Line yAxisId="right" type="monotone" dataKey="ts" name="Target Share %" />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* TEAM ANALYTICS */}
+          <TabsContent value="teams" className="space-y-4">
+            <Card className="rounded-2xl border">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">Team Analytics (prototype)</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <div className="w-full h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={[{t:'Team A',rz:6,pace:63},{t:'Team B',rz:3,pace:58},{t:'Team C',rz:8,pace:67},{t:'Team D',rz:5,pace:60}] }>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis dataKey="t" />
+                      <YAxis />
+                      <Tooltip />
+                      <Legend />
+                      <Bar dataKey="rz" name="Red Zone Trips" />
+                      <Bar dataKey="pace" name="Plays/Game" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+                <div className="w-full h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={[{w:1,wp:42},{w:2,wp:55},{w:3,wp:48},{w:4,wp:61},{w:5,wp:58}] }>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis dataKey="w" label={{ value: 'Week', position: 'insideBottom', dy: 8 }} />
+                      <YAxis label={{ value: 'Win % (elo model)', angle: -90, position: 'insideLeft' }} />
+                      <Tooltip />
+                      <Legend />
+                      <Line type="monotone" dataKey="wp" name="Win Probability" />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* FUN METRICS */}
+          <TabsContent value="fun" className="space-y-4">
+            <Card className="rounded-2xl border">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">Fun / Novel Metrics (preview)</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm text-muted-foreground">
+                <div>
+                  <div className="font-medium text-foreground">Hype Volatility Index</div>
+                  Std‑dev of last 4 weeks' fantasy points, adjusted for snap share & opponent.
+                </div>
+                <div>
+                  <div className="font-medium text-foreground">Clutch Meter</div>
+                  Points scored in 4th quarter / overtime vs team average.
+                </div>
+                <div>
+                  <div className="font-medium text-foreground">Red‑Zone Gravity</div>
+                  Share of team targets/carries inside the 10.
+                </div>
+                <div>
+                  <div className="font-medium text-foreground">Game Script Sensitivity</div>
+                  Usage delta when trailing by 7+ vs leading by 7+.
+                </div>
+                <div>
+                  <div className="font-medium text-foreground">Route Win Rate+</div>
+                  Targets per route vs league‑avg at same aDOT band.
+                </div>
+                <div>
+                  <div className="font-medium text-foreground">Luck Index</div>
+                  Actual points vs xPoints based on expected TDs & opponent allowances.
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* LEAGUE TAB: Teams & Rosters */}
+          <TabsContent value="league" className="space-y-4">
+            <Card className="rounded-2xl border">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">League Directory & Rosters</CardTitle>
+                <p className="text-xs text-muted-foreground">
+                  {leagueMeta ? `${leagueMeta.name} • ${leagueMeta.season} • ${leagueMeta.total_rosters} teams` : 'Sync to load league meta'}
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button size="sm" variant="outline" onClick={() => loadPlayers(false)} disabled={playersStatus==='loading'}>
+                    {playersStatus==='loading' ? 'Loading players…' : (playersStatus==='ready' ? 'Refresh players (cache)' : 'Load player names (~5MB)')}
+                  </Button>
+                  {playersStatus==='ready' && (<Badge variant="secondary">Players cached</Badge>)}
+                </div>
+
+                {/* Team cards */}
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {leagueRosters.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No rosters yet. Click Sync Sleeper above.</p>
+                  ) : (
+                    leagueRosters.map((r) => {
+                      const owner = leagueUsers.find(u => u.user_id === r.owner_id);
+                      const teamLabel = rosterDisplayName(r, new Map(leagueUsers.map(u=>[u.user_id,u] as const)));
+                      return (
+                        <Card key={r.roster_id} className="border rounded-xl">
+                          <CardHeader className="pb-2">
+                            <CardTitle className="text-sm flex items-center justify-between">
+                              <span className="truncate">{teamLabel}</span>
+                              <Badge variant="outline">Roster #{r.roster_id}</Badge>
+                            </CardTitle>
+                            {owner?.display_name && (<p className="text-xs text-muted-foreground">Manager: {owner.display_name}</p>)}
+                          </CardHeader>
+                          <CardContent>
+                            {/* Starters & Bench */}
+                            <div className="grid grid-cols-2 gap-3 text-xs">
+                              <div>
+                                <div className="font-medium mb-1">Starters</div>
+                                <ul className="space-y-1">
+                                  {(r.starters ?? []).map(pid => (
+                                    <li key={pid} className="flex items-center justify-between">
+                                      <span className="truncate pr-2">{fmtPlayer(pid, playersDict)}</span>
+                                      <span className="text-muted-foreground">{fmtPos(pid, playersDict)}</span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              </div>
+                              <div>
+                                <div className="font-medium mb-1">Bench</div>
+                                <ul className="space-y-1">
+                                  {computeBench(r).map(pid => (
+                                    <li key={pid} className="flex items-center justify-between">
+                                      <span className="truncate pr-2">{fmtPlayer(pid, playersDict)}</span>
+                                      <span className="text-muted-foreground">{fmtPos(pid, playersDict)}</span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              </div>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      );
+                    })
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* TOOLS */}
+          <TabsContent value="tools" className="space-y-4">
+            <Card className="rounded-2xl border">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">Tools (roadmap)</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground space-y-4">
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>Lineup Optimizer w/ projections & constraints</li>
+                  <li>Trade Analyzer w/ rest‑of‑season EV</li>
+                  <li>Schedule Strength Explorer & Playoff Planner</li>
+                  <li>Alerts: role changes (routes, carries), injuries, weather</li>
+                </ul>
+
+                {/* Self-tests */}
+                <div className="border rounded-lg p-3">
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="font-medium">Self‑tests</div>
+                    <Button size="sm" variant="outline" onClick={runAllTests}>Run</Button>
+                  </div>
+                  {testResults ? (
+                    <ul className="text-xs grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2">
+                      {testResults.map((t, i) => (
+                        <li key={i} className={t.ok ? "text-green-600" : "text-red-600"}>
+                          {t.ok ? "✔" : "✘"} {t.name}{t.details ? ` — ${t.details}` : ""}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">No tests run yet. Click Run to verify series sum and monotonicity for every matchup.</p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+
+        {/* Footer note */}
+        <p className="text-xs text-muted-foreground text-center">
+          Wire Sleeper + projections when ready. Tabs show the structure we can iterate on fast.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---- Helper functions used only by League tab rendering ----
+function computeBench(r: SleeperRoster): string[] {
+  const starters = new Set(r.starters ?? []);
+  const players = r.players ?? [];
+  return players.filter((p) => !starters.has(p));
+}
+
+function fmtPlayer(pid: string, dict: PlayersDict | null): string {
+  if (!pid) return '—';
+  const p = dict ? dict[pid] : undefined;
+  if (p) {
+    const name = p.full_name || [p.first_name, p.last_name].filter(Boolean).join(' ');
+    const team = p.team || '';
+    return team ? `${name} (${team})` : name || pid;
+  }
+  if (pid.length <= 3 && pid.toUpperCase() === pid) return `${pid} D/ST`;
+  return pid;
+}
+
+function fmtPos(pid: string, dict: PlayersDict | null): string {
+  const p = dict ? dict[pid] : undefined;
+  if (!p) return '';
+  // Avoid optional chaining with indexed access to keep older Babel/TS configs happy
+  const fp = Array.isArray(p.fantasy_positions) ? p.fantasy_positions : [];
+  const first = fp.length > 0 ? fp[0] : '';
+  return p.position || first || '';
+}

--- a/src/tests/providers.test.ts
+++ b/src/tests/providers.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { mergeProjections } from '../api/providers/merge';
+import type { ProjectionProvider } from '../api/providers/interfaces';
+
+describe('provider merge', () => {
+  const players = [{ player_id: '1' }, { player_id: '2' }];
+  const provider: ProjectionProvider = {
+    source: 'Mock',
+    ttlMs: 0,
+    isEnabled: true,
+    fetchWeekly: async () => ({ '1': 10, '2': 20 }),
+  };
+  it('enriches when enabled', async () => {
+    const res = await mergeProjections(players, provider, 1);
+    expect(res[0].projection).toBe(10);
+    expect(res[0].source).toBe('Mock');
+  });
+  it('passes through when disabled', async () => {
+    const res = await mergeProjections(players, { ...provider, isEnabled: false }, 1);
+    expect(res[0].projection).toBeUndefined();
+  });
+  it('graceful on failure', async () => {
+    const res = await mergeProjections(players, { ...provider, fetchWeekly: async () => { throw new Error(); } }, 1);
+    expect(res[0].projection).toBeUndefined();
+  });
+});

--- a/src/tests/series.test.ts
+++ b/src/tests/series.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { generateSeries, maskFuture } from '../utils/series';
+
+describe('series', () => {
+  it('deterministic and sums to final', () => {
+    const s1 = generateSeries('a', 50.5);
+    const s2 = generateSeries('a', 50.5);
+    expect(s1).toEqual(s2);
+    expect(s1.length).toBe(61);
+    expect(s1[0]).toBe(0);
+    for (let i = 1; i < s1.length; i++) expect(s1[i] >= s1[i - 1]).toBe(true);
+    const final = s1[s1.length - 1];
+    expect(final).toBeCloseTo(50.5, 9);
+  });
+
+  it('maskFuture masks items', () => {
+    const arr = maskFuture([0, 1, 2], 1);
+    expect(arr[2]).toBeNull();
+  });
+});

--- a/src/tests/time.test.ts
+++ b/src/tests/time.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { fmtHourLabel, hourLabelIndices } from '../utils/time';
+
+describe('time utils', () => {
+  it('hour labels', () => {
+    expect(hourLabelIndices.length).toBe(11);
+    expect(hourLabelIndices[0]).toBe(0);
+    expect(hourLabelIndices[10]).toBe(60);
+    expect(fmtHourLabel(0)).toBe('12p');
+    expect(fmtHourLabel(60)).toBe('10p');
+  });
+});

--- a/src/types/sleeper.ts
+++ b/src/types/sleeper.ts
@@ -1,0 +1,42 @@
+export interface NFLState {
+  season_type: string;
+  week: number;
+  display_week?: number;
+  league?: number;
+}
+
+export interface League {
+  league_id: string;
+  name: string;
+  season: string;
+  total_rosters: number;
+}
+
+export interface User {
+  user_id: string;
+  display_name: string;
+}
+
+export interface Roster {
+  roster_id: number;
+  owner_id: string;
+  starters: string[];
+  bench: string[];
+  metadata: Record<string, string>;
+}
+
+export interface Matchup {
+  matchup_id: number;
+  roster_id: number;
+  points: number;
+}
+
+export interface Player {
+  player_id: string;
+  full_name: string;
+  team?: string;
+  position?: string;
+  fantasy_positions?: string[];
+}
+
+export type Players = Record<string, Player>;

--- a/src/utils/series.ts
+++ b/src/utils/series.ts
@@ -1,0 +1,45 @@
+// Synthetic series generator with deterministic seeded RNG
+
+function fnv1a(str: string): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function mulberry32(seed: number): () => number {
+  return function () {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function generateSeries(seed: string, total: number): number[] {
+  const rand = mulberry32(fnv1a(seed));
+  const increments: number[] = new Array(61).fill(0);
+  for (let i = 1; i < 61; i++) {
+    if (rand() < 0.9) continue;
+    increments[i] = rand();
+  }
+  const sum = increments.reduce((a, b) => a + b, 0) || 1;
+  const scale = total / sum;
+  const series: number[] = [0];
+  for (let i = 1; i < increments.length; i++) {
+    const next = series[i - 1] + increments[i] * scale;
+    series.push(next);
+  }
+  const final = Number(total.toFixed(1));
+  series[series.length - 1] = final;
+  for (let i = series.length - 2; i >= 0; i--) {
+    if (series[i] > final) series[i] = final;
+  }
+  return series.map((v) => Number(v.toFixed(1)));
+}
+
+export function maskFuture(series: number[], lastIndex: number): (number | null)[] {
+  return series.map((v, i) => (i > lastIndex ? null : v));
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,7 @@
+export const hourLabelIndices = Array.from({ length: 11 }, (_, i) => i * 6);
+
+export function fmtHourLabel(index: number): string {
+  const hour24 = 12 + Math.floor(index / 6);
+  const display = hour24 > 12 ? hour24 - 12 : hour24;
+  return `${display}${hour24 >= 12 && hour24 < 24 ? 'p' : 'a'}`;
+}


### PR DESCRIPTION
## Summary
- add full-featured `FantasyMatchups` dashboard page with charts, rosters, analytics tabs, and self-tests
- implement minimal Tailwind-based UI primitives (`Card`, `Tabs`, `Select`, etc.) to support the new page
- route app to use `FantasyMatchups`

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68ab90ba49c0832a8699edc913cd4fec